### PR TITLE
Switch email delivery to Brevo

### DIFF
--- a/main.py
+++ b/main.py
@@ -213,7 +213,9 @@ def upload_file():
                                                         newsletter_preview = preview_html
                                                         recipient = os.getenv("SEND_TO_EMAIL")
                                                         subject = "Your Daily Newsletter"
-                                                        if email_html:
+                                                        if not recipient:
+                                                                email_status = "SEND_TO_EMAIL not configured."
+                                                        elif email_html:
                                                                 sent = agent_send_newsletter_email(
                                                                         subject,
                                                                         newsletter_markdown,


### PR DESCRIPTION
## Summary
- replace the SendGrid email integration with Brevo, using the v3 SMTP API and required headers
- require SEND_FROM_EMAIL, SEND_TO_EMAIL, and BREVO_API_KEY environment variables before attempting to send
- surface configuration issues to the UI when SEND_TO_EMAIL is missing

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68c9f20bab34832ab20c6689d2ed2eb9